### PR TITLE
Hotfix/build errors

### DIFF
--- a/include/jenlib/gpio/PinTypes.h
+++ b/include/jenlib/gpio/PinTypes.h
@@ -28,10 +28,10 @@ class TypedPin {
     const Pin& getPin() const noexcept { return pin_; }
 
     //! @brief Get the raw pin index.
-    PinIndex getIndex() const noexcept { return pin_.getIndex(); }
+    PinIndex getIndex() const noexcept { return pin_.index(); }
 
     //! @brief Implicit conversion to raw pin number for library compatibility.
-    operator PinIndex() const noexcept { return pin_.getIndex(); }
+    operator PinIndex() const noexcept { return pin_.index(); }
 
     //! @brief Implicit conversion to GPIO::Pin for GPIO operations.
     operator const Pin&() const noexcept { return pin_; }

--- a/include/jenlib/onewire/OneWireBus.h
+++ b/include/jenlib/onewire/OneWireBus.h
@@ -38,7 +38,7 @@ class OneWireBus {
 
         //! @brief Constructor with type-safe pin.
         //! @param pin The typed pin to use for the OneWire bus.
-        explicit OneWireBus(GPIO::OneWirePin pin);
+        explicit OneWireBus(gpio::OneWirePin pin);
         //! @brief Constructor with generic GPIO pin.
         //! @param pin The GPIO pin to use for the OneWire bus.
         explicit OneWireBus(GPIO::Pin pin);

--- a/src/gpio/drivers/EspIdfGpioDriver.cpp
+++ b/src/gpio/drivers/EspIdfGpioDriver.cpp
@@ -63,7 +63,7 @@ void EspIdfGpioDriver::analog_write(PinIndex pin, std::uint16_t value) noexcept 
 std::uint16_t EspIdfGpioDriver::analog_read(PinIndex pin) noexcept {
     // Configure ADC
     adc1_config_width(convert_adc_bits_width(analog_read_bits_));
-    adc1_config_channel_atten(static_cast<adc1_channel_t>(pin), ADC_ATTEN_DB_11);
+    adc1_config_channel_atten(static_cast<adc1_channel_t>(pin), ADC_ATTEN_DB_12);
 
     // Read ADC value
     int adc_reading = adc1_get_raw(static_cast<adc1_channel_t>(pin));
@@ -157,14 +157,20 @@ gpio_pull_mode_t EspIdfGpioDriver::convert_pull_mode(PinMode mode) const noexcep
 
 adc_bits_width_t EspIdfGpioDriver::convert_adc_bits_width(std::uint8_t bits) const noexcept {
     switch (bits) {
+        #if CONFIG_IDF_TARGET_ESP32
         case 9:
             return ADC_WIDTH_BIT_9;
         case 10:
             return ADC_WIDTH_BIT_10;
         case 11:
             return ADC_WIDTH_BIT_11;
+        #elif SOC_ADC_RTC_MAX_BITWIDTH == 12
         case 12:
             return ADC_WIDTH_BIT_12;
+        #elif SOC_ADC_RTC_MAX_BITWIDTH == 13
+        case 13:
+            return ADC_WIDTH_BIT_13;
+        #endif
         default:
             // Default to 12-bit resolution for unsupported bit widths
             return ADC_WIDTH_BIT_12;

--- a/src/measurement/Measurement.cpp
+++ b/src/measurement/Measurement.cpp
@@ -6,7 +6,7 @@
 
 #include "jenlib/measurement/Measurement.h"
 
-namespace measurement {
+namespace jenlib::measurement {
 
 bool Measurement::serialize(const Measurement &measurement, jenlib::ble::BlePayload &payload) {
     payload.clear();

--- a/src/measurement/Measurement.cpp
+++ b/src/measurement/Measurement.cpp
@@ -75,4 +75,4 @@ bool Measurement::deserialize(jenlib::ble::BlePayload &&payload, Measurement &me
     return true;
 }
 
-}  // namespace measurement
+}  // namespace jenlib::measurement


### PR DESCRIPTION
- Changed usage of namespaces to no longer produce errors
- Fix error with usage of class Pin
- Fixed deprication warning and 
- Check if flags are defined for ADC_WIDTH_BIT_X (9-13)